### PR TITLE
Factored out strace-related code into a new API

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -7,5 +7,6 @@ java_binary(
             "@slf4j//:compile",
             "@logback_classic//:compile"],
     srcs = glob(["src/org/dux/cli/*.java", 
-                 "src/org/dux/backingstore/*.java"]),
+                 "src/org/dux/backingstore/*.java",
+		 "src/org/dux/stracetool/*.java"]),
 )

--- a/src/org/dux/stracetool/README.md
+++ b/src/org/dux/stracetool/README.md
@@ -1,0 +1,18 @@
+#Strace Tool
+
+The Strace Tool library can be used to abstract the functionality of a
+system-call tracing utility (such as strace on Linux) across platforms*.
+
+There are multiple entry points into the library, depending on your
+project needs:
+
+>List\<StraceCall> StraceParser.parse("path to strace log file") \
+> TODO add more here...
+
+Note: Windows users will need to install Process Monitor, a free download from
+Microsoft here: https://docs.microsoft.com/en-us/sysinternals/downloads/procmon .
+Process Monitor is an advanced system monitoring tool, which (among other
+features), can trace a process' system calls. Process Monitor is in no way 
+affiliated with this project and its use is governed by its own separate EULA.
+
+\* Currently only Linux (e.g. CentOS) and Windows (kind of).

--- a/src/org/dux/stracetool/StraceCall.java
+++ b/src/org/dux/stracetool/StraceCall.java
@@ -1,24 +1,24 @@
-package org.dux.cli;
+package org.dux.stracetool;
 
 import java.util.Arrays;
 
 /**
  * Object that stores information parsed from strace calls
  */
-public class DuxStraceCall {
+public class StraceCall {
     public final String call;
     public final String[] args;
     public final boolean knownReturn;
     public final int returnValue;
 
-    public DuxStraceCall(String call, String[] args, int returnValue) {
+    public StraceCall(String call, String[] args, int returnValue) {
         this.call = call;
         this.args = Arrays.<String>copyOf(args, args.length);
         this.knownReturn = true;
         this.returnValue = returnValue;
     }
 
-    public DuxStraceCall(String call, String[] args) {
+    public StraceCall(String call, String[] args) {
         this.call = call;
         this.args = Arrays.<String>copyOf(args, args.length);
         this.knownReturn = false;
@@ -27,7 +27,7 @@ public class DuxStraceCall {
 
     @Override
     public String toString() {
-        return "DuxStraceCall{"
+        return "StraceCall{"
                 + "call=\"" + call + "\", "
                 + "args=\"" + Arrays.toString(args) + "\", "
                 + "knownReturn=" + knownReturn + ", "

--- a/src/org/dux/stracetool/StraceParser.java
+++ b/src/org/dux/stracetool/StraceParser.java
@@ -1,0 +1,54 @@
+package org.dux.stracetool;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+// TODO What to do about DuxCLI references (primarily debug statements)?
+import org.dux.cli.DuxCLI;
+
+import java.io.BufferedReader;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class StraceParser {
+    public static List<StraceCall> parse(String path)
+            throws IOException, FileNotFoundException {
+        String os = System.getProperty("os.name");
+        StraceParser sp = null;
+        if (os.startsWith("Linux")) {
+            sp = new LinuxStraceParser();
+        } else if (os.startsWith("Windows")) {
+            // TODO implement
+        } else {
+            return null;
+        }
+        return sp.parseFile(path);
+    }
+
+    protected List<StraceCall> parseFile(String path)
+            throws IOException, FileNotFoundException {
+        ArrayList<StraceCall> calls = new ArrayList<>();
+
+        DuxCLI.logger.debug("creating a file reader and a buffered reader");
+
+        try (FileReader fr = new FileReader(path);
+             BufferedReader br = new BufferedReader(fr)) {
+            while (br.ready()) {
+                DuxCLI.logger.debug("buffer is ready");
+                String line = br.readLine();
+                DuxCLI.logger.debug("read this line: {}", line);
+                StraceCall call = parseLine(line);
+                if (call == null) {
+                    continue;
+                }
+
+                calls.add(call);
+            }
+        }
+
+        return calls;
+    }
+
+    protected abstract @Nullable StraceCall parseLine(String line);
+}

--- a/src/org/dux/stracetool/Tracer.java
+++ b/src/org/dux/stracetool/Tracer.java
@@ -1,0 +1,78 @@
+package org.dux.stracetool;
+
+import org.dux.cli.DuxCLI;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.IOException;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class Tracer {
+    // TODO Allow for arbitrary temp file names (need to sanitize in constructor)
+    private static final String TMP_FILE = ".dux_out";
+    private String[] args;
+
+    private static final String[] STRACE_CALL = {
+            "strace",
+            "-o", TMP_FILE               // write to tmp file
+    };
+
+    private static final String[] PROCMON_CALL = {
+            "TODO implement"
+    };
+
+    public Tracer(List<String> args) {
+        String os = System.getProperty("os.name");
+        List<String> argList = null;
+        if (os.startsWith("Linux")) {
+            argList = new ArrayList<>(Arrays.asList(STRACE_CALL));
+        } else if (os.startsWith("Windows")) {
+            // TODO implement
+            argList = new ArrayList<>(Arrays.asList(PROCMON_CALL));
+        } else {
+            // TODO What to do here?
+        }
+        System.out.println("args = " + args);
+        argList.addAll(args);
+        System.out.println("args = " + argList);
+        this.args = argList.toArray(new String[0]);
+    }
+
+    // https://stackoverflow.com/questions/1732455/redirect-process-output-to-stdout
+    class StreamGobbler extends Thread {
+        InputStream is;
+
+        // reads everything from is until empty.
+        StreamGobbler(InputStream is) {
+            this.is = is;
+        }
+
+        public void run() {
+            try {
+                InputStreamReader isr = new InputStreamReader(is);
+                BufferedReader br = new BufferedReader(isr);
+                String line=null;
+                while ( (line = br.readLine()) != null)
+                    System.out.println(line);
+            } catch (IOException ioe) {
+                ioe.printStackTrace();
+            }
+        }
+    }
+
+    public void trace() throws IOException, InterruptedException {
+        DuxCLI.logger.debug("beginning a trace, getting runtime");
+        Runtime rt = Runtime.getRuntime();
+        DuxCLI.logger.debug("runtime acquired, executing program");
+        System.out.println(Arrays.toString(args));
+        Process proc = rt.exec(args);
+        Tracer.StreamGobbler outputGobbler = new Tracer.StreamGobbler(proc.getInputStream());
+        DuxCLI.logger.debug("waiting for build to terminate");
+        outputGobbler.start();
+        proc.waitFor();
+    }
+}


### PR DESCRIPTION
This commit basically tries to extract all the strace-related functionality from git and separate that from the rest of the dux-specific code, by making  a new package, src/dux/stracetool. To that end, I also rename stuff that started with Dux (e.g. DuxStraceCall to StraceCall).

I also restructured the StraceParser, so there is now an abstract class StraceParser which, given a method to parse a line, can parse a whole file (provided by the abstract class). It has a subclass LinuxStraceParser that inherits that and provides the Linux specific (strace-specific) implementation of parsing a line. We will eventually also add a subclass WindowsStraceParser.

I noticed that you had made that interface static, so you could use the convenient invocation StraceParser.parse, and I left that alone. But, to resolve some issue with protected/private and static, I needed to change the subclasses to not have static helper methods. So now, the parse method in StraceParser is just a wrapper that dispatches to the appropriate Linux or Windows strace parser.

I also refactored the DuxBuildTracer to use composition on a new Tracer object, which again is just abstracting the details of strace away.

I made this new temp branch because I didn't want to force the broken changes to the .travis.yml to your branch.